### PR TITLE
Ensure that we only paint road textures where roads should be

### DIFF
--- a/src/procgen/orchestration/chunks/LSystemVillageChunk.cs
+++ b/src/procgen/orchestration/chunks/LSystemVillageChunk.cs
@@ -10,6 +10,8 @@ public class LSystemVillageChunk : LayerChunk<LSystemVillageLayer, LSystemVillag
 {
     List<Vector3> housePositions = new();
     List<(Vector3, Vector3)> roadPositionDirections = new();
+    List<int> roadStartIndices = new();
+    List<int> roadEndIndices = new();
     Point gridOrigin;
     private Node3D? _chunkParent; 
     private readonly List<Node3D> _pendingHouses = new();
@@ -112,7 +114,9 @@ public class LSystemVillageChunk : LayerChunk<LSystemVillageLayer, LSystemVillag
             lSequence,
             turtleState,
             housePositions,
-            roadPositionDirections
+            roadPositionDirections,
+            roadStartIndices,
+            roadEndIndices
         );
 
         // Sensechecking.
@@ -134,6 +138,8 @@ public class LSystemVillageChunk : LayerChunk<LSystemVillageLayer, LSystemVillag
             SignalBus.SignalName.RoadsGenerated,
             roadPositions.ToArray(),
             roadDirections.ToArray(),
+            roadStartIndices.ToArray(),
+            roadEndIndices.ToArray(),
             index.ToVector3());
     }
 

--- a/src/procgen/orchestration/l_system/TurtleInterpreter.cs
+++ b/src/procgen/orchestration/l_system/TurtleInterpreter.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System.Collections.Generic;
 using System;
+using Runevision.Common;
 
 public class TurtleInterpreter
 {
@@ -30,7 +31,9 @@ public class TurtleInterpreter
         string sequence,
         TurtleState state,
         List<Vector3> housePositions,
-        List<(Vector3, Vector3)> roadPositionDirections
+        List<(Vector3, Vector3)> roadPositionDirections,
+        List<int> roadStartIndices,
+        List<int> roadEndIndices
     ) {
         foreach (char symbol in sequence)
         {
@@ -49,8 +52,15 @@ public class TurtleInterpreter
                     break;
 
                 // Branch markers (no extra rotation here!)
-                case '[': stack.Push(state.Clone()); break;
-                case ']': if (stack.Count > 0) state = stack.Pop(); break;
+                case '[': {
+                    stack.Push(state.Clone());
+                    roadStartIndices.Add(roadPositionDirections.Count);
+                    break;
+                }
+                case ']': {
+                    roadEndIndices.Add(roadPositionDirections.Count);
+                    if (stack.Count > 0) state = stack.Pop(); break;
+                }
 
                 case '|':                               // turn around
                     state.Direction = state.Direction.Rotated(Vector3.Up, Mathf.Pi);

--- a/src/signals/SignalBus.cs
+++ b/src/signals/SignalBus.cs
@@ -3,7 +3,12 @@ using Godot;
 public partial class SignalBus : Node
 {
     [Signal]
-    public delegate void RoadsGeneratedEventHandler(Vector3[] roadPositions, Vector3[] roadDirections, Vector3 chunkIndex);
+    public delegate void RoadsGeneratedEventHandler(
+        Vector3[] roadPositions,
+        Vector3[] roadDirections, 
+        int[] roadStartIndices,
+        int[] roadEndIndices,
+        Vector3 chunkIndex);
 
     // Singleton instance reference (set this script as an autoload in Project Settings).
     public static SignalBus Instance { get; private set; }


### PR DESCRIPTION
### Description

- Introduce idea of subroads for l-system generated string
- Track subroad start and end indices
- Update RoadsGenerated signal to track this information
- Populate these holders with the turtle interpreter for [ and ] chars
- Ensure in the RoadPainter that we compute subroads based on these, then make a subcall to a new PaintSubRoad function for each
- Ensure that we don't loop back from start to end by setting start + end indices for each subroad appropriately

### Screenshot

<img width="954" alt="Screenshot 2025-05-07 at 7 51 46 AM" src="https://github.com/user-attachments/assets/cbf15329-3172-4c34-9d75-e6dce05412ae" />

