### PR TITLE
Address crashes by implementing lock mechanism + count landscape chunk generation

### DIFF
--- a/src/procgen/layers/LSystemVillageLayer.cs
+++ b/src/procgen/layers/LSystemVillageLayer.cs
@@ -15,7 +15,6 @@ public class LSystemVillageLayer : ChunkBasedDataLayer<LSystemVillageLayer, LSys
     public static int gridDoneCounter { get; set; } = 0;
 
     public static string layerName { get; } = nameof(LSystemVillageLayer);
-    private static NodePath _terrainPath { get; set; } = new NodePath("TerrainPath");
     static readonly int TotalChunks = 25;
     
     static readonly Action createChunkReadyDefault = static () =>
@@ -31,7 +30,7 @@ public class LSystemVillageLayer : ChunkBasedDataLayer<LSystemVillageLayer, LSys
         gridDoneCounter++;
         if (gridDoneCounter >= TotalChunks)
         {
-            GD.Print("✅  All chunks finished generating, emitting signal to VillageManagerService");
+            GD.Print("✅ All chunks finished generating, emitting signal to VillageManagerService");
             SignalBus.Instance.CallDeferred(
                 "emit_signal",
                 SignalBus.SignalName.AllLSystemVillageChunksGenerated
@@ -58,13 +57,6 @@ public class LSystemVillageLayer : ChunkBasedDataLayer<LSystemVillageLayer, LSys
         if (args.parameters
                  .TryGetValue(myKey, out var layerParams))
         {
-            // Handle terrain path as before
-            if (layerParams.TryGetValue("TerrainPath", out var pathVariant))
-            {
-                var nodePath = new NodePath(pathVariant.AsString());
-                _terrainPath = nodePath;
-            }
-
             // Handle timer creation if specified
             if (layerParams.TryGetValue("Node:Timer", out var timerSignalVariant))
             {

--- a/src/procgen/orchestration/terrainObjects/blackboard/LandscapeChunkCounterBlackboard.cs
+++ b/src/procgen/orchestration/terrainObjects/blackboard/LandscapeChunkCounterBlackboard.cs
@@ -1,0 +1,14 @@
+public static class LandscapeChunkCounterBlackboard
+{
+    public static Godot.Collections.Dictionary<string, int> ChunkCountDictionary = new()
+    {
+        { "LandscapeLayerA", 0 },
+        { "LandscapeLayerB", 0 },
+        { "LandscapeLayerC", 0 },
+        { "LandscapeLayerD", 0 }
+    };
+
+    public static int GridDoneCounter { get; set; } = 0;
+
+    public static readonly object ChunkCountLock = new();
+}

--- a/src/procgen/orchestration/terrainObjects/blackboard/LandscapeChunkCounterBlackboard.cs.uid
+++ b/src/procgen/orchestration/terrainObjects/blackboard/LandscapeChunkCounterBlackboard.cs.uid
@@ -1,0 +1,1 @@
+uid://cmqa06eemc241

--- a/src/signals/SignalBus.cs
+++ b/src/signals/SignalBus.cs
@@ -25,6 +25,9 @@ public partial class SignalBus : Node
     [Signal]
     public delegate void LSystemVillageChunkReadyEventHandler();
 
+    [Signal]
+    public delegate void LandscapeChunksReadyEventHandler();
+
     // Singleton instance reference (set this script as an autoload in Project Settings).
     public static SignalBus Instance { get; private set; }
 


### PR DESCRIPTION
- With a view to triggering the LSystemVillageLayer constructor if and only if the landscape layers are first done, track how many are generated /w a hardcoded dictionary of total counts
- As part of this it was necessary to create a LandscapeChunkCounterBlackboard /w a lock mechanism, so as to not have race conditions caused by multiple threads writing on top of each other (an alternative approach if keen to get high performance could be to look into a Semaphore based approach for async work)

Looks like implementing a locking mechanism on a blackboard object is enough to fix crashes, and this doesn't seem to slow execution of the example. So I think this is good enough for now, if all else fails I will look into the Semaphore mechanism + see if I need to properly orchestrate the LSystemVillageLayer to run _after_ the LandscapeLayers