### PR TITLE
Introduce optional callback action for LayerDependency objects + use for LSystemVillageLayer

### DIFF
--- a/addons/LayerProcGen/Common/Debugging/SimpleProfiler.cs
+++ b/addons/LayerProcGen/Common/Debugging/SimpleProfiler.cs
@@ -72,8 +72,10 @@ namespace Runevision.Common {
 		static Dictionary<int, ProfilerInfo> dict = new Dictionary<int, ProfilerInfo>();
 		static StringBuilder statusBuilder = new StringBuilder();
 		static int currentTotal;
+		
 
-		public static bool AnyCurrent() {
+		public static bool AnyCurrent()
+		{
 			return currentTotal == 0;
 		}
 
@@ -194,7 +196,7 @@ namespace Runevision.Common {
 
 		static void StatusRecursive(StringBuilder logString, ProfilerInfo info, int level) {
 			if (level >= 0) {
-				int indent = level * 2;
+				int indent = Math.Max(0, level * 2); // Prevent negative indent
 				logString.AppendFormat("{0}{1} {2}\n",
 					new string(' ', indent),
 					info.name,

--- a/addons/LayerProcGen/Godot/LayerProcGen/LayerManagerBehavior.cs
+++ b/addons/LayerProcGen/Godot/LayerProcGen/LayerManagerBehavior.cs
@@ -93,7 +93,9 @@ namespace Runevision.LayerProcGen
 			if (debugQueueText is { Visible: true })
 				debugQueueText.Text = MainThreadActionQueue.idle ? string.Empty : "Action Queue: " + MainThreadActionQueue.queueCount;
 			if (debugStatusText is { Visible: true })
-				debugStatusText.Text = SimpleProfiler.GetStatus();
+				Callable.From(() => {
+					debugStatusText.Text = SimpleProfiler.GetStatus();
+				}).CallDeferred();
 		}
 
 		public void StartCoroutine(IEnumerator coroutine)

--- a/addons/LayerProcGen/LayerProcGen/ChunkBasedDataLayer.cs
+++ b/addons/LayerProcGen/LayerProcGen/ChunkBasedDataLayer.cs
@@ -275,9 +275,20 @@ namespace Runevision.LayerProcGen {
 			// External dependencies on other layers.
 			foreach (LayerDependency dependency in dependencies[level])
 			{
+				// GD.Print($"Adding dependency {dependency.layer.GetType().Name} to {GetType().Name}");
 				GridBounds requiredBounds = chunkBounds;
 				requiredBounds.Expand(dependency.hPadding, dependency.hPadding, dependency.vPadding, dependency.vPadding);
-				dependency.layer.EnsureLoadedInBounds(requiredBounds, dependency.level, levelData);
+
+				if (dependency.Callback != null)
+				{
+					// Defer the dependency loading to the callback
+					dependency.Callback.Invoke(requiredBounds, dependency.level, levelData);
+				}
+				else
+				{
+					// Immediate loading as before
+					dependency.layer.EnsureLoadedInBounds(requiredBounds, dependency.level, levelData);
+				}
 			}
 		}
 

--- a/addons/LayerProcGen/LayerProcGen/LayerChunk.cs
+++ b/addons/LayerProcGen/LayerProcGen/LayerChunk.cs
@@ -17,7 +17,7 @@ namespace Runevision.LayerProcGen {
 	/// <summary>
 	/// Internal. A level of a chunk, or alternatively a root usage of a layer.
 	/// </summary>
-	internal class ChunkLevelData : IPoolable {
+	public class ChunkLevelData : IPoolable {
 		/// <summary>
 		/// A provider chunk and level that another chunk and level depends on.
 		/// </summary>

--- a/addons/LayerProcGen/LayerProcGen/LayerDependency.cs
+++ b/addons/LayerProcGen/LayerProcGen/LayerDependency.cs
@@ -7,18 +7,21 @@
  */
 
 using Runevision.Common;
+using System;
 
 namespace Runevision.LayerProcGen {
 
 	/// <summary>
 	/// A layer's dependency on another with a specified level and padding.
 	/// </summary>
-	public class LayerDependency {
+	public class LayerDependency
+	{
 
 		public AbstractChunkBasedDataLayer layer;
 		public int level;
 		public int vPadding;
 		public int hPadding;
+		public Action<GridBounds, int, ChunkLevelData> Callback { get; set; }
 
 		public LayerDependency(AbstractChunkBasedDataLayer layer, int padding)
 			: this(layer, padding, padding) { }
@@ -28,11 +31,25 @@ namespace Runevision.LayerProcGen {
 			: this(layer, padding.x, padding.y, layer.GetLevelCount() - 1) { }
 		public LayerDependency(AbstractChunkBasedDataLayer layer, Point padding, int level)
 			: this(layer, padding.x, padding.y, level) { }
-		public LayerDependency(AbstractChunkBasedDataLayer layer, int hPadding, int vPadding, int level) {
+		public LayerDependency(AbstractChunkBasedDataLayer layer, int hPadding, int vPadding, int level)
+		{
 			this.layer = layer;
 			this.hPadding = hPadding;
 			this.vPadding = vPadding;
 			this.level = level;
+		}
+		public LayerDependency(
+			AbstractChunkBasedDataLayer layer,
+			int hPadding,
+			int vPadding,
+			int level,
+			Action<GridBounds, int, ChunkLevelData> callback = null)
+		{
+			this.layer = layer;
+			this.hPadding = hPadding;
+			this.vPadding = vPadding;
+			this.level = level;
+			this.Callback = callback;
 		}
 	}
 

--- a/addons/LayerProcGen/Unity/LayerProcGen/LayerManagerBehavior.cs
+++ b/addons/LayerProcGen/Unity/LayerProcGen/LayerManagerBehavior.cs
@@ -55,7 +55,9 @@ namespace Runevision.LayerProcGen {
 				debugQueueText.text = MainThreadActionQueue.idle ? string.Empty
 					: "Action Queue: " + MainThreadActionQueue.queueCount;
 			if (debugStatusText && debugStatusText.enabled)
-				debugStatusText.text = SimpleProfiler.GetStatus();
+				Callable.From(() => {
+					debugStatusText.Text = SimpleProfiler.GetStatus();
+				}).CallDeferred();
 #endif
 		}
 	}

--- a/src/procgen/layers/PlayLayer.cs
+++ b/src/procgen/layers/PlayLayer.cs
@@ -2,11 +2,27 @@ using System.Reflection;
 using Godot;
 using Runevision.LayerProcGen;
 using Runevision.Common;
+using System;
 
 public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
 {
     public override int chunkW => 8;
     public override int chunkH => 8;
+    
+    private bool _subscribed = false;
+    private GridBounds _pendingBounds;
+    private int _pendingLevel;
+    private ChunkLevelData _pendingLevelData;
+
+    private void OnLandscapeChunksReady()
+    {
+        // This will be set by the dependency logic in ChunkBasedDataLayer
+        if (_pendingBounds != null && _pendingLevelData != null)
+        {
+            LSystemVillageLayer.instance.EnsureLoadedInBounds(_pendingBounds, _pendingLevel, _pendingLevelData);
+            GD.Print("LSystemVillageLayer dependency loaded after LandscapeChunksReady signal.");
+        }
+    }
 
     public PlayLayer()
     {
@@ -14,13 +30,20 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
 
         AddLayerDependency(new LayerDependency(LandscapeLayerD.instance, 2048, 2048));
         AddLayerDependency(new LayerDependency(LandscapeLayerC.instance, 1024, 1024));
-        AddLayerDependency(new LayerDependency(LandscapeLayerB.instance,  512,  512));
-        AddLayerDependency(new LayerDependency(LandscapeLayerA.instance,  256,  256));
+        AddLayerDependency(new LayerDependency(LandscapeLayerB.instance, 512, 512));
+        AddLayerDependency(new LayerDependency(LandscapeLayerA.instance, 256, 256));
 
         AddLayerDependency(new LayerDependency(
             LSystemVillageLayer.instance,
             256,
-            256
+            256,
+            LSystemVillageLayer.instance.GetLevelCount() - 1,
+            (bounds, level, levelData) => {
+                SignalBus.Instance.LandscapeChunksReady += () => {
+                    LSystemVillageLayer.instance.EnsureLoadedInBounds(bounds, level, levelData);
+                    GD.Print("LSystemVillageLayer dependency loaded after LandscapeChunksReady signal.");
+                };
+            }
         ));
         // GD.Print("PlayLayer Create");
     }

--- a/src/procgen/services/village/VillageService.cs
+++ b/src/procgen/services/village/VillageService.cs
@@ -55,6 +55,7 @@ namespace LayerProcGenExampleProject.Services
             RoadPainterService roadPainterService)
             : base("Village") // Pass the required layerName to the base constructor
         {
+            GD.Print("VillageService: Constructor called.");
             _databaseService = databaseService;
             _turtleInterpreterService = turtleInterpreterService;
             _roadPainterService = roadPainterService;
@@ -64,8 +65,7 @@ namespace LayerProcGenExampleProject.Services
 
         private void OnAllLSystemVillageChunksGenerated()
         {
-            // Handle the event when all L-System village chunks are generated.
-            GD.Print("All L-System village chunks have been generated.");
+            GD.Print("VillageService: All L-System village chunks have been generated.");
         }
 
         private void OnLSystemVillageChunkReady() { }


### PR DESCRIPTION
- In order to try once again to fix our occasional crashes, let's introduce 
  a callback Action as an optional argument to the LayerDependency
  constructor
- We can set this for our LSystemVillageLayer + connect to a hook in our
  PlayLayer so as to only perform the Village Generation work once the
  Landscape layers are done.
- CallDeferred for the Simple Profiler's get status method to avert
  race conditions, + place a guard on the layer cardinality so to
  protect against checking a negative layer value.