### PR TITLE
Fix road generation duplication

### DIFF
--- a/src/procgen/services/road_painter/RoadPainterService.cs
+++ b/src/procgen/services/road_painter/RoadPainterService.cs
@@ -181,7 +181,6 @@ public class RoadPainterService
         // Merge, avoiding duplicate intermediate point
         left.RemoveAt(left.Count - 1);
         left.AddRange(right);
-        left.Add(b);
         return left;
     }
 


### PR DESCRIPTION
## Summary
- fix duplication of final waypoint in `GenerateNoisyWaypoints`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e950356483259641f7020de94e4a