### PR TITLE
Fix typo in FreeLookCamera comment

### DIFF
--- a/src/procgen/orchestration/behaviours/FreeLookCamera.gd
+++ b/src/procgen/orchestration/behaviours/FreeLookCamera.gd
@@ -42,7 +42,7 @@ func _input(event):
 				Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED if event.pressed else Input.MOUSE_MODE_VISIBLE)
 			MOUSE_BUTTON_WHEEL_UP: # Increases max velocity
 				_vel_multiplier = clamp(_vel_multiplier * 1.1, 0.2, 200)
-			MOUSE_BUTTON_WHEEL_DOWN: # Decereases max velocity
+			MOUSE_BUTTON_WHEEL_DOWN: # Decreases max velocity
 				_vel_multiplier = clamp(_vel_multiplier / 1.1, 0.2, 200)
 
 	# Receives key input


### PR DESCRIPTION
## Summary
- correct a typo in FreeLookCamera's wheel-down comment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843eb7470188325ba7ab150edbdd6c2