### PR TITLE
Lazy evaluation for l-system village layer chunks

### DIFF
--- a/addons/LayerProcGen/Godot/LayerProcGen/VisualizationManager.cs
+++ b/addons/LayerProcGen/Godot/LayerProcGen/VisualizationManager.cs
@@ -112,7 +112,7 @@ namespace Runevision.LayerProcGen
 			SignalBus.Instance.GenerationSourceReady += layerArguments =>
 			{
 				layerArguments.Merge(this.layerArguments);
-				GD.Print($"VisualizationManager ready with layer arguments: {layerArguments.ToString()}");
+				// GD.Print($"VisualizationManager ready with layer arguments: {layerArguments.ToString()}");
 				UpdateLayers();
 				SetupVisualization();
 			};

--- a/src/procgen/layers/LSystemVillageLayer.cs
+++ b/src/procgen/layers/LSystemVillageLayer.cs
@@ -157,7 +157,7 @@ public class LSystemVillageLayer : ChunkBasedDataLayer<LSystemVillageLayer, LSys
             layerArguments: layerArguments
         )
     { 
-        GD.Print("LSystemVillageLayer constructor with LayerArgumentDictionary called");
+        // GD.Print("LSystemVillageLayer constructor with LayerArgumentDictionary called");
     }
 
     /// <summary>

--- a/src/procgen/layers/PlayLayer.cs
+++ b/src/procgen/layers/PlayLayer.cs
@@ -13,19 +13,28 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
 
     private readonly PlayerPositionManager _playerManager;
     private readonly LandscapeLayerOrchestrator _landscapeOrchestrator;
+    private readonly VillageLayerOrchestrator _villageOrchestrator;
     private readonly LazyEvaluationHandler _lazyEvaluationHandler;
-    private bool _isVillageLayerChunksDone = false;
+    private LayerArgumentDictionary _pendingLayerArguments;
+    private bool _playerSpawnHandlerSubscribed = false;
 
     public PlayLayer()
     {
+        GD.Print($"[PlayLayer] Default constructor called - Instance ID: {GetHashCode()}");
         _playerManager = new PlayerPositionManager();
         _landscapeOrchestrator = new LandscapeLayerOrchestrator(this, _playerManager);
-        _lazyEvaluationHandler = new LazyEvaluationHandler(this, _playerManager, _landscapeOrchestrator);
+        _villageOrchestrator = new VillageLayerOrchestrator(this, _playerManager);
+        _lazyEvaluationHandler = new LazyEvaluationHandler(
+            this,
+            _playerManager,
+            _landscapeOrchestrator,
+            _villageOrchestrator);
     }
 
     public PlayLayer(LayerArgumentDictionary layerArguments) : this()
     {
-        GD.Print($"PlayLayer created with arguments: {layerArguments}");
+        GD.Print($"PlayLayer created with arguments: {layerArguments} - Instance ID: {GetHashCode()}");
+
         InitializePlayLayer(layerArguments);
     }
 
@@ -33,62 +42,76 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
     {
         TerrainBlackboard.Initialize(new NodePath("Controller/TerrainLODManager/Terrain3D"));
 
-        bool hasPlayerPosition = _playerManager.TryInitializeFromArguments(layerArguments);
-
-        if (hasPlayerPosition)
+        // Subscribe to PlayerSpawn signal immediately
+        if (!_playerSpawnHandlerSubscribed)
         {
-            GD.Print($"[PlayLayer] Initial player position: {_playerManager.LastKnownPlayerPosition}");
-            _landscapeOrchestrator.SetupLandscapeLayersWithLazyLoading(layerArguments, _playerManager.LastKnownPlayerPosition);
-        }
-        else
-        {
-            GD.Print("[PlayLayer] No player position found, using default loading");
-            _landscapeOrchestrator.SetupLandscapeLayersDefault(layerArguments);
+            SignalBus.Instance.PlayerSpawn += OnPlayerSpawn;
+            _playerSpawnHandlerSubscribed = true;
+            GD.Print("[PlayLayer] Subscribed to PlayerSpawn signal");
         }
 
-        SetupVillageLayer(layerArguments);
+        _playerManager.InitializeFromArguments(layerArguments);
+
+        // Store the arguments for later use when PlayerSpawn signal is received
+        _pendingLayerArguments = layerArguments;
+
+        // Callable.From(() => CheckForExistingPlayer()).CallDeferred();
+        
         Callable.From(_lazyEvaluationHandler.HookSignalsDeferred).CallDeferred();
     }
+    
+    // private void CheckForExistingPlayer()
+    // {
+    //     if (_pendingLayerArguments != null) // Only if we haven't processed the spawn yet
+    //     {
+    //         try
+    //         {
+    //             var sceneTree = Engine.GetMainLoop() as SceneTree;
+    //             if (sceneTree?.CurrentScene != null)
+    //             {
+    //                 // Look for FreeLookCamera or any camera
+    //                 var cameraNode = sceneTree.CurrentScene.FindChild("*Camera*", true, false) as Node3D;
+    //                 if (cameraNode != null)
+    //                 {
+    //                     GD.Print($"[PlayLayer] Found existing camera/player at: {cameraNode.GlobalPosition}");
+    //                     OnPlayerSpawn(cameraNode.GlobalPosition);
+    //                     return;
+    //                 }
+    //             }
+    //         }
+    //         catch (System.Exception e)
+    //         {
+    //             GD.Print($"[PlayLayer] Error checking for existing player: {e.Message}");
+    //         }
+            
+    //         GD.Print("[PlayLayer] No existing camera found, waiting for signal");
+    //     }
+    // }
 
-    private void VillageChunkDoneCallback(GridBounds bounds, int level, ChunkLevelData levelData, LSystemVillageLayer villageLayer)
+    private void OnPlayerSpawn(Vector3 playerPosition)
     {
-        // Note, we may want to revise this functionality for the village chunk callback (this logic block)
-        // if and when we implement proper lazy loading for the village layer.
-        if (_isVillageLayerChunksDone)
+        if (_pendingLayerArguments == null)
         {
+            GD.Print("[PlayLayer] PlayerSpawn received but no pending layer arguments");
             return;
         }
 
-        void Handler()
-        {
-            if (!LandscapeChunkCounterBlackboard.LandscapeChunksAreReady)
-            {
-                return;
-            }
-            villageLayer.EnsureLoadedInBounds(bounds, level, levelData);
-            _isVillageLayerChunksDone = true;
-            GD.Print("LSystemVillageLayer dependency loaded after LandscapeChunksReady signal.");
-        }
+        GD.Print($"[PlayLayer] PlayerSpawn received at position: {playerPosition}");
 
-        SignalBus.Instance.LandscapeChunksReady += Handler;
+        // Update player manager with the actual spawned position
+        _playerManager.UpdatePlayerPosition(playerPosition);
 
-        if (LandscapeChunkCounterBlackboard.LandscapeChunksAreReady)
-        {
-            Handler();
-        }
+        GD.Print($"[PlayLayer] Initial player position: {_playerManager.LastKnownPlayerPosition}");
+        _landscapeOrchestrator.SetupLandscapeLayersWithLazyLoading(_pendingLayerArguments, _playerManager.LastKnownPlayerPosition);
+        _villageOrchestrator.SetupLSystemVillageLayerWithLazyLoading(_pendingLayerArguments, _playerManager.LastKnownPlayerPosition);
 
-    }
+        // Clear pending arguments as they've been processed
+        _pendingLayerArguments = null;
 
-    private void SetupVillageLayer(LayerArgumentDictionary layerArguments)
-    {
-        var villageLayer = LSystemVillageLayer.GetInstance(layerArguments);
+        // Unsubscribe from PlayerSpawn signal as we only need it once
+        SignalBus.Instance.PlayerSpawn -= OnPlayerSpawn;
+        _playerSpawnHandlerSubscribed = false;
 
-        AddLayerDependency(new LayerDependency(
-            villageLayer,
-            256,
-            256,
-            villageLayer.GetLevelCount() - 1,
-            (bounds, level, levelData) => VillageChunkDoneCallback(bounds, level, levelData, villageLayer)
-        ));
+        GD.Print("[PlayLayer] Layer setup completed based on PlayerSpawn signal");
     }
 }

--- a/src/procgen/layers/PlayLayer.cs
+++ b/src/procgen/layers/PlayLayer.cs
@@ -20,7 +20,7 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
 
     public PlayLayer()
     {
-        GD.Print($"[PlayLayer] Default constructor called - Instance ID: {GetHashCode()}");
+        // GD.Print($"[PlayLayer] Default constructor called - Instance ID: {GetHashCode()}");
         _playerManager = new PlayerPositionManager();
         _landscapeOrchestrator = new LandscapeLayerOrchestrator(this, _playerManager);
         _villageOrchestrator = new VillageLayerOrchestrator(this, _playerManager);
@@ -33,7 +33,7 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
 
     public PlayLayer(LayerArgumentDictionary layerArguments) : this()
     {
-        GD.Print($"PlayLayer created with arguments: {layerArguments} - Instance ID: {GetHashCode()}");
+        // GD.Print($"PlayLayer created with arguments: {layerArguments} - Instance ID: {GetHashCode()}");
 
         InitializePlayLayer(layerArguments);
     }
@@ -42,66 +42,53 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
     {
         TerrainBlackboard.Initialize(new NodePath("Controller/TerrainLODManager/Terrain3D"));
 
-        // Subscribe to PlayerSpawn signal immediately
-        if (!_playerSpawnHandlerSubscribed)
-        {
-            SignalBus.Instance.PlayerSpawn += OnPlayerSpawn;
-            _playerSpawnHandlerSubscribed = true;
-            GD.Print("[PlayLayer] Subscribed to PlayerSpawn signal");
-        }
+        // Defer subscription to ensure the SignalBus singleton is ready.
+        Callable.From(SubscribeToPlayerSpawn).CallDeferred();
 
         _playerManager.InitializeFromArguments(layerArguments);
 
         // Store the arguments for later use when PlayerSpawn signal is received
         _pendingLayerArguments = layerArguments;
 
-        // Callable.From(() => CheckForExistingPlayer()).CallDeferred();
         
         Callable.From(_lazyEvaluationHandler.HookSignalsDeferred).CallDeferred();
     }
     
-    // private void CheckForExistingPlayer()
-    // {
-    //     if (_pendingLayerArguments != null) // Only if we haven't processed the spawn yet
-    //     {
-    //         try
-    //         {
-    //             var sceneTree = Engine.GetMainLoop() as SceneTree;
-    //             if (sceneTree?.CurrentScene != null)
-    //             {
-    //                 // Look for FreeLookCamera or any camera
-    //                 var cameraNode = sceneTree.CurrentScene.FindChild("*Camera*", true, false) as Node3D;
-    //                 if (cameraNode != null)
-    //                 {
-    //                     GD.Print($"[PlayLayer] Found existing camera/player at: {cameraNode.GlobalPosition}");
-    //                     OnPlayerSpawn(cameraNode.GlobalPosition);
-    //                     return;
-    //                 }
-    //             }
-    //         }
-    //         catch (System.Exception e)
-    //         {
-    //             GD.Print($"[PlayLayer] Error checking for existing player: {e.Message}");
-    //         }
-            
-    //         GD.Print("[PlayLayer] No existing camera found, waiting for signal");
-    //     }
-    // }
+    private void SubscribeToPlayerSpawn()
+    {
+        if (_playerSpawnHandlerSubscribed) return;
+
+        // This is the robust way to get a singleton from a non-Node class
+        var sceneTree = Engine.GetMainLoop() as SceneTree;
+        var signalBus = sceneTree?.Root.GetNode<SignalBus>("SignalBus");
+
+        if (signalBus == null)
+        {
+            // GD.PrintErr("[PlayLayer] Could not find SignalBus singleton in the scene tree!");
+            return;
+        }
+        
+        signalBus.PlayerSpawn += OnPlayerSpawn;
+        _playerSpawnHandlerSubscribed = true;
+        // GD.Print($"[PlayLayer] Subscribed to PlayerSpawn signal on SignalBus instance {signalBus.GetInstanceId()}");
+    }
 
     private void OnPlayerSpawn(Vector3 playerPosition)
     {
+        // GD.Print($"[PlayLayer] OnPlayerSpawn called with position: {playerPosition}");
+
         if (_pendingLayerArguments == null)
         {
             GD.Print("[PlayLayer] PlayerSpawn received but no pending layer arguments");
             return;
         }
 
-        GD.Print($"[PlayLayer] PlayerSpawn received at position: {playerPosition}");
+        // GD.Print($"[PlayLayer] PlayerSpawn received at position: {playerPosition}");
 
         // Update player manager with the actual spawned position
         _playerManager.UpdatePlayerPosition(playerPosition);
 
-        GD.Print($"[PlayLayer] Initial player position: {_playerManager.LastKnownPlayerPosition}");
+        // GD.Print($"[PlayLayer] Initial player position: {_playerManager.LastKnownPlayerPosition}");
         _landscapeOrchestrator.SetupLandscapeLayersWithLazyLoading(_pendingLayerArguments, _playerManager.LastKnownPlayerPosition);
         _villageOrchestrator.SetupLSystemVillageLayerWithLazyLoading(_pendingLayerArguments, _playerManager.LastKnownPlayerPosition);
 
@@ -109,7 +96,14 @@ public class PlayLayer : ChunkBasedDataLayer<PlayLayer, PlayChunk, LayerService>
         _pendingLayerArguments = null;
 
         // Unsubscribe from PlayerSpawn signal as we only need it once
-        SignalBus.Instance.PlayerSpawn -= OnPlayerSpawn;
+        // Also get the singleton properly here to unsubscribe
+        var sceneTree = Engine.GetMainLoop() as SceneTree;
+        var signalBus = sceneTree?.Root.GetNode<SignalBus>("SignalBus");
+        if (signalBus != null)
+        {
+            signalBus.PlayerSpawn -= OnPlayerSpawn;
+        }
+        
         _playerSpawnHandlerSubscribed = false;
 
         GD.Print("[PlayLayer] Layer setup completed based on PlayerSpawn signal");

--- a/src/procgen/layers/playLayer/LandscapeLayerOrchestrator.cs
+++ b/src/procgen/layers/playLayer/LandscapeLayerOrchestrator.cs
@@ -114,7 +114,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
 
                 if (!withinRange)
                 {
-                    GD.Print($"[Initial Load] Skipping {layer.GetType().Name} chunk {chunkIndex} - outside player range (distance: {distanceToPlayer:F1})");
+                    // GD.Print($"[Initial Load] Skipping {layer.GetType().Name} chunk {chunkIndex} - outside player range (distance: {distanceToPlayer:F1})");
                 }
 
                 return withinRange;
@@ -123,7 +123,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
             var initialBounds = GetBoundsAroundPosition(playerPosition, loadDistance * 1.2f);
             ChunkLevelData levelData = ObjectPool<ChunkLevelData>.GlobalGet();
 
-            GD.Print($"[Initial Load] Loading {layer.GetType().Name} chunks around player at {playerPosition}");
+            // GD.Print($"[Initial Load] Loading {layer.GetType().Name} chunks around player at {playerPosition}");
             try
             {
                 layer.EnsureLoadedInBounds(initialBounds, 0, levelData, playerPosition, ShouldCreateChunk);

--- a/src/procgen/layers/playLayer/LazyEvaluationHandler.cs
+++ b/src/procgen/layers/playLayer/LazyEvaluationHandler.cs
@@ -9,16 +9,19 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
         private readonly PlayLayer _playLayer;
         private readonly PlayerPositionManager _playerManager;
         private readonly LandscapeLayerOrchestrator _landscapeOrchestrator;
+        private readonly VillageLayerOrchestrator _villageOrchestrator;
         private bool _subscribed;
 
         public LazyEvaluationHandler(
             PlayLayer playLayer,
             PlayerPositionManager playerManager,
-            LandscapeLayerOrchestrator landscapeOrchestrator)
+            LandscapeLayerOrchestrator landscapeOrchestrator,
+            VillageLayerOrchestrator villageOrchestrator)
         {
             _playLayer = playLayer;
             _playerManager = playerManager;
             _landscapeOrchestrator = landscapeOrchestrator;
+            _villageOrchestrator = villageOrchestrator;
         }
 
         public void HookSignalsDeferred()
@@ -50,6 +53,9 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
 
             // Handle Landscape layer chunks
             HandleLandscapeLayerReconstruction(referencePosition);
+
+            // Handle Village layer chunks
+            HandleVillageLayerReconstruction(referencePosition);
         }
 
         // This is an expensive operation and should be used with caution.
@@ -70,19 +76,6 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
         //         ObjectPool<ChunkLevelData>.GlobalReturn(ref levelData);
         //     }
         // }
-
-        private void HandleLandscapeLayerReconstruction(Vector3 referencePosition)
-        {
-            // GD.Print($"[LazyEvaluationHandler] Reconstructing LandscapeLayer chunks around {referencePosition}");
-            _playLayer.HandleDependenciesForLevel(0, dependency =>
-            {
-                var layer = dependency.layer;
-                if (layer.GetType().Name.StartsWith("LandscapeLayer"))
-                {
-                    _landscapeOrchestrator.UpdateLayerBasedOnCameraMovement(layer, referencePosition, dependency);
-                }
-            });
-        }
 
         // private bool ShouldCreatePlayChunk(Point chunkIndex, int level, Vector3 playerPosition)
         // {
@@ -105,5 +98,31 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
         //         (int)(range * 2)
         //     );
         // }
+
+        private void HandleLandscapeLayerReconstruction(Vector3 referencePosition)
+        {
+            // GD.Print($"[LazyEvaluationHandler] Reconstructing LandscapeLayer chunks around {referencePosition}");
+            _playLayer.HandleDependenciesForLevel(0, dependency =>
+            {
+                var layer = dependency.layer;
+                if (layer.GetType().Name.StartsWith("LandscapeLayer"))
+                {
+                    _landscapeOrchestrator.UpdateLayerBasedOnCameraMovement(layer, referencePosition, dependency);
+                }
+            });
+        }
+        
+        private void HandleVillageLayerReconstruction(Vector3 referencePosition)
+        {
+            // GD.Print($"[LazyEvaluationHandler] Reconstructing Village chunks around {referencePosition}");
+            _playLayer.HandleDependenciesForLevel(0, dependency =>
+            {
+                var layer = dependency.layer;
+                if (layer.GetType().Name == "LSystemVillageLayer")
+                {
+                    _villageOrchestrator.UpdateVillageLayerBasedOnCameraMovement((LSystemVillageLayer)layer, referencePosition);
+                }
+            });
+        }
     }
 }

--- a/src/procgen/layers/playLayer/PlayLayerConfiguration.cs
+++ b/src/procgen/layers/playLayer/PlayLayerConfiguration.cs
@@ -8,6 +8,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
         public const int CHUNK_WIDTH = 8;
         public const int CHUNK_HEIGHT = 8;
         public const float PLAY_LAYER_LOAD_DISTANCE = 75f;
+        public const float VILLAGE_LAYER_LOAD_DISTANCE = 150f;
 
         public static readonly LandscapeLayerConfig[] LandscapeLayerConfigs = new[]
         {
@@ -25,6 +26,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
                 "LandscapeLayerC" => 150f,
                 "LandscapeLayerB" => 100f,
                 "LandscapeLayerA" => 75f,
+                "LSystemVillageLayer" => VILLAGE_LAYER_LOAD_DISTANCE,
                 _ => 100f
             };
         }

--- a/src/procgen/layers/playLayer/PlayerPositionManager.cs
+++ b/src/procgen/layers/playLayer/PlayerPositionManager.cs
@@ -21,7 +21,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
 
             // Set default position, will be updated when PlayerSpawn signal is received
             _lastKnownPlayerPosition = Vector3.Zero;
-            GD.Print("[PlayerPositionManager] Initialized with arguments, waiting for PlayerSpawn signal");
+            // GD.Print("[PlayerPositionManager] Initialized with arguments, waiting for PlayerSpawn signal");
         }
 
         public Vector3 GetCurrentPlayerPosition()
@@ -49,7 +49,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
         public void UpdatePlayerPosition(Vector3 newPosition)
         {
             _lastKnownPlayerPosition = newPosition;
-            GD.Print($"[PlayerPositionManager] Player position updated to: {newPosition}");
+            // GD.Print($"[PlayerPositionManager] Player position updated to: {newPosition}");
 
             // Now that we have a confirmed player position, try to find and cache the player node
             if (_cachedPlayerNode == null && _storedLayerArguments != null)
@@ -61,14 +61,14 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
         private void TryFindAndCachePlayerNode()
         {
             _cachedPlayerNode = FindPlayerNode(_storedLayerArguments);
-            if (_cachedPlayerNode != null)
-            {
-                GD.Print($"[PlayerPositionManager] Successfully cached player node: {_cachedPlayerNode.Name}");
-            }
-            else
-            {
-                GD.Print("[PlayerPositionManager] Could not find player node, will use signal-provided position");
-            }
+            // if (_cachedPlayerNode != null)
+            // {
+            //     GD.Print($"[PlayerPositionManager] Successfully cached player node: {_cachedPlayerNode.Name}");
+            // }
+            // else
+            // {
+            //     GD.Print("[PlayerPositionManager] Could not find player node, will use signal-provided position");
+            // }
         }
 
         private Node3D FindPlayerNode(LayerArgumentDictionary layerArguments)

--- a/src/procgen/layers/playLayer/PlayerPositionManager.cs
+++ b/src/procgen/layers/playLayer/PlayerPositionManager.cs
@@ -9,23 +9,19 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
     {
         private Node3D _cachedPlayerNode;
         private Vector3 _lastKnownPlayerPosition;
+        private LayerArgumentDictionary _storedLayerArguments;
 
         public Node3D CachedPlayerNode => _cachedPlayerNode;
         public Vector3 LastKnownPlayerPosition => _lastKnownPlayerPosition;
 
-        public bool TryInitializeFromArguments(LayerArgumentDictionary layerArguments)
+        public void InitializeFromArguments(LayerArgumentDictionary layerArguments)
         {
-            _cachedPlayerNode = FindPlayerNode(layerArguments);
+            // Store the arguments for later use when PlayerSpawn signal is received
+            _storedLayerArguments = layerArguments;
 
-            var playerPosition = ExtractPlayerPosition(layerArguments);
-            if (playerPosition.HasValue)
-            {
-                _lastKnownPlayerPosition = playerPosition.Value;
-                GD.Print($"[PlayerPositionManager] Found and cached player at: {_lastKnownPlayerPosition}");
-                return true;
-            }
-
-            return false;
+            // Set default position, will be updated when PlayerSpawn signal is received
+            _lastKnownPlayerPosition = Vector3.Zero;
+            GD.Print("[PlayerPositionManager] Initialized with arguments, waiting for PlayerSpawn signal");
         }
 
         public Vector3 GetCurrentPlayerPosition()
@@ -50,23 +46,29 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
             return _lastKnownPlayerPosition;
         }
 
-        private Vector3? ExtractPlayerPosition(LayerArgumentDictionary layerArguments)
+        public void UpdatePlayerPosition(Vector3 newPosition)
         {
-            if (!layerArguments.parameters.TryGetValue("PlayLayer", out var playLayerDict) ||
-                playLayerDict == null ||
-                !playLayerDict.ContainsKey("PlayerPath"))
-                return null;
+            _lastKnownPlayerPosition = newPosition;
+            GD.Print($"[PlayerPositionManager] Player position updated to: {newPosition}");
 
-            string playerPath = playLayerDict["PlayerPath"].AsString();
-
-            if (Engine.IsEditorHint())
+            // Now that we have a confirmed player position, try to find and cache the player node
+            if (_cachedPlayerNode == null && _storedLayerArguments != null)
             {
-                GD.Print($"[PlayerPositionManager] Editor mode - cannot resolve player path: {playerPath}");
-                return null;
+                TryFindAndCachePlayerNode();
             }
+        }
 
-            var playerNode = FindPlayerNodeByPath(playerPath);
-            return playerNode?.GlobalPosition;
+        private void TryFindAndCachePlayerNode()
+        {
+            _cachedPlayerNode = FindPlayerNode(_storedLayerArguments);
+            if (_cachedPlayerNode != null)
+            {
+                GD.Print($"[PlayerPositionManager] Successfully cached player node: {_cachedPlayerNode.Name}");
+            }
+            else
+            {
+                GD.Print("[PlayerPositionManager] Could not find player node, will use signal-provided position");
+            }
         }
 
         private Node3D FindPlayerNode(LayerArgumentDictionary layerArguments)
@@ -96,6 +98,13 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
                 var sceneTree = Engine.GetMainLoop() as SceneTree;
                 if (sceneTree?.CurrentScene != null)
                 {
+                    // Add a check to see if the scene is ready
+                    if (!sceneTree.CurrentScene.IsInsideTree())
+                    {
+                        GD.Print($"[PlayerPositionManager] Scene not ready yet for path: {playerPath}");
+                        return null;
+                    }
+
                     if (playerPath == ".")
                     {
                         playerNode = sceneTree.CurrentScene as Node3D;
@@ -106,8 +115,20 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
                     }
                     else
                     {
-                        playerNode = sceneTree.CurrentScene.GetNode(playerPath) as Node3D;
+                        // Use HasNode to check existence before GetNode
+                        if (sceneTree.CurrentScene.HasNode(playerPath))
+                        {
+                            playerNode = sceneTree.CurrentScene.GetNode(playerPath) as Node3D;
+                        }
+                        else
+                        {
+                            GD.Print($"[PlayerPositionManager] Player path '{playerPath}' not found in scene yet");
+                        }
                     }
+                }
+                else
+                {
+                    GD.Print("[PlayerPositionManager] Scene tree or current scene not available yet");
                 }
             }
             catch (Exception e)
@@ -115,15 +136,34 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
                 GD.Print($"[PlayerPositionManager] Could not resolve player path '{playerPath}': {e.Message}");
             }
 
-            // Try groups as fallback
+            // Try groups as fallback only if scene is ready
             if (playerNode == null)
             {
-                var sceneTree = Engine.GetMainLoop() as SceneTree;
-                var playersInGroup = sceneTree?.GetNodesInGroup("player");
-                if (playersInGroup?.Count > 0)
+                try
                 {
-                    playerNode = playersInGroup[0] as Node3D;
+                    var sceneTree = Engine.GetMainLoop() as SceneTree;
+                    if (sceneTree?.CurrentScene?.IsInsideTree() == true)
+                    {
+                        var playerNodes = sceneTree.GetNodesInGroup("player");
+                        if (playerNodes.Count > 0)
+                        {
+                            playerNode = playerNodes[0] as Node3D;
+                            if (playerNode != null)
+                            {
+                                GD.Print($"[PlayerPositionManager] Found player node via group: {playerNode.Name}");
+                            }
+                        }
+                    }
                 }
+                catch (Exception e)
+                {
+                    GD.Print($"[PlayerPositionManager] Error finding player via group: {e.Message}");
+                }
+            }
+
+            if (playerNode != null)
+            {
+                GD.Print($"[PlayerPositionManager] Successfully found player node: {playerNode.Name} at {playerNode.GlobalPosition}");
             }
 
             return playerNode;

--- a/src/procgen/layers/playLayer/VillageLayerOrchestrator.cs
+++ b/src/procgen/layers/playLayer/VillageLayerOrchestrator.cs
@@ -1,0 +1,156 @@
+using System;
+using Godot;
+using Runevision.LayerProcGen;
+using Runevision.Common;
+
+namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
+{
+    public class VillageLayerOrchestrator
+    {
+        private readonly PlayLayer _playLayer;
+        private readonly PlayerPositionManager _playerManager;
+        private bool _isVillageLayerChunksDone = false;
+
+        public VillageLayerOrchestrator(PlayLayer playLayer, PlayerPositionManager playerManager)
+        {
+            _playLayer = playLayer;
+            _playerManager = playerManager;
+        }
+
+        public void SetupLSystemVillageLayerWithLazyLoading(LayerArgumentDictionary layerArguments, Vector3 playerPosition)
+        {
+            var villageLayer = LSystemVillageLayer.GetInstance(layerArguments);
+
+            // Perform initial lazy load for the village layer
+            PerformInitialLazyLoadForVillageLayer(villageLayer, playerPosition);
+
+            _playLayer.AddLayerDependency(new LayerDependency(
+                villageLayer,
+                256,
+                256,
+                villageLayer.GetLevelCount() - 1,
+                (bounds, level, levelData) => VillageChunkDoneCallback(bounds, level, levelData, villageLayer)
+            ));
+        }
+
+        public void SetupLSystemVillageLayerDefault(LayerArgumentDictionary layerArguments)
+        {
+            var villageLayer = LSystemVillageLayer.GetInstance(layerArguments);
+
+            _playLayer.AddLayerDependency(new LayerDependency(
+                villageLayer,
+                256,
+                256,
+                villageLayer.GetLevelCount() - 1,
+                (bounds, level, levelData) => VillageChunkDoneCallback(bounds, level, levelData, villageLayer)
+            ));
+        }
+
+        private void PerformInitialLazyLoadForVillageLayer(LSystemVillageLayer villageLayer, Vector3 playerPosition)
+        {
+            // Define load distance for village layer (you can add this to PlayLayerConfiguration)
+            float villageLoadDistance = 150f; // Adjust as needed
+
+            bool ShouldCreateChunk(Point chunkIndex, int level, Vector3 playerPos)
+            {
+                var chunkWorldPos = new Vector3(
+                    chunkIndex.x * villageLayer.chunkW + villageLayer.chunkW / 2,
+                    0,
+                    chunkIndex.y * villageLayer.chunkH + villageLayer.chunkH / 2
+                );
+
+                var playerXZPos = new Vector3(playerPos.X, 0, playerPos.Z);
+                var distanceToPlayer = playerXZPos.DistanceTo(chunkWorldPos);
+                bool withinRange = distanceToPlayer <= villageLoadDistance;
+
+                if (!withinRange)
+                {
+                    GD.Print($"[Initial Load] Skipping Village chunk {chunkIndex} - outside player range (distance: {distanceToPlayer:F1})");
+                }
+
+                return withinRange;
+            }
+
+            var initialBounds = GetBoundsAroundPosition(playerPosition, villageLoadDistance * 1.2f);
+            ChunkLevelData levelData = ObjectPool<ChunkLevelData>.GlobalGet();
+
+            GD.Print($"[Initial Load] Loading Village chunks around player at {playerPosition}");
+            try
+            {
+                villageLayer.EnsureLoadedInBounds(initialBounds, 0, levelData, playerPosition, ShouldCreateChunk);
+            }
+            finally
+            {
+                ObjectPool<ChunkLevelData>.GlobalReturn(ref levelData);
+            }
+        }
+
+        public void UpdateVillageLayerBasedOnCameraMovement(
+            LSystemVillageLayer villageLayer,
+            Vector3 referencePosition)
+        {
+            float loadDistance = 150f; // You can add this to PlayLayerConfiguration
+
+            bool ShouldCreateChunk(Point chunkIndex, int level, Vector3 playerPos)
+            {
+                var chunkWorldPos = new Vector3(
+                    chunkIndex.x * villageLayer.chunkW + villageLayer.chunkW / 2,
+                    0,
+                    chunkIndex.y * villageLayer.chunkH + villageLayer.chunkH / 2
+                );
+
+                var playerPosXZ = new Vector3(playerPos.X, 0, playerPos.Z);
+                return playerPosXZ.DistanceTo(chunkWorldPos) <= loadDistance;
+            }
+
+            var bounds = GetBoundsAroundPosition(referencePosition, loadDistance * 1.5f);
+            ChunkLevelData levelData = ObjectPool<ChunkLevelData>.GlobalGet();
+
+            GD.Print($"[Camera Movement] Updating Village chunks around camera at {referencePosition}");
+            try
+            {
+                villageLayer.EnsureLoadedInBounds(bounds, 0, levelData, referencePosition, ShouldCreateChunk);
+            }
+            finally
+            {
+                ObjectPool<ChunkLevelData>.GlobalReturn(ref levelData);
+            }
+        }
+
+        private void VillageChunkDoneCallback(GridBounds bounds, int level, ChunkLevelData levelData, LSystemVillageLayer villageLayer)
+        {
+            if (_isVillageLayerChunksDone)
+            {
+                return;
+            }
+
+            void Handler()
+            {
+                if (!LandscapeChunkCounterBlackboard.LandscapeChunksAreReady)
+                {
+                    return;
+                }
+                villageLayer.EnsureLoadedInBounds(bounds, level, levelData);
+                _isVillageLayerChunksDone = true;
+                GD.Print("LSystemVillageLayer dependency loaded after LandscapeChunksReady signal.");
+            }
+
+            SignalBus.Instance.LandscapeChunksReady += Handler;
+
+            if (LandscapeChunkCounterBlackboard.LandscapeChunksAreReady)
+            {
+                Handler();
+            }
+        }
+
+        private static GridBounds GetBoundsAroundPosition(Vector3 position, float range)
+        {
+            return new GridBounds(
+                (int)(position.X - range),
+                (int)(position.Z - range),
+                (int)(range * 2),
+                (int)(range * 2)
+            );
+        }
+    }
+}

--- a/src/procgen/layers/playLayer/VillageLayerOrchestrator.cs.uid
+++ b/src/procgen/layers/playLayer/VillageLayerOrchestrator.cs.uid
@@ -1,0 +1,1 @@
+uid://bq4mnts4uedf2

--- a/src/procgen/orchestration/TerrainLODManager.cs
+++ b/src/procgen/orchestration/TerrainLODManager.cs
@@ -65,7 +65,7 @@ public partial class TerrainLODManager : Node
 			{
 				{ "id", "LandscapeLayerA" }
 			};
-			GD.Print($"TerrainLODManager ready with layer arguments: {layerArguments.ToString()}");
+			// GD.Print($"TerrainLODManager ready with layer arguments: {layerArguments.ToString()}");
 			SetupLODLayer(0, LandscapeLayerA.GetInstance(layerArguments, "A"));
 		};
 		instance = this;

--- a/src/procgen/orchestration/behaviours/FreeLookCamera.cs
+++ b/src/procgen/orchestration/behaviours/FreeLookCamera.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System;
 
 [GlobalClass]
 public partial class FreeLookCamera : Camera3D
@@ -40,17 +41,21 @@ public partial class FreeLookCamera : Camera3D
         // Defer the PlayerSpawn signal emission to ensure all subscribers are ready
         Callable.From(() => EmitPlayerSpawnSignal()).CallDeferred();
 
-        GD.Print($"[FreeLookCamera] Player spawned at position: {GlobalTransform.Origin}");
+        // GD.Print($"[FreeLookCamera] SignalBus instance ID: {SignalBus.Instance.GetInstanceId()}");
+
+        // GD.Print($"[FreeLookCamera] Player spawned at position: {GlobalTransform.Origin}");
     }
 
     private void EmitPlayerSpawnSignal()
     {
+        // GD.Print($"[FreeLookCamera] About to emit PlayerSpawn signal with position: {GlobalTransform.Origin}");
+        
         SignalBus.Instance.CallDeferred(
             "emit_signal",
             SignalBus.SignalName.PlayerSpawn,
             GlobalTransform.Origin
         );
-        GD.Print($"[FreeLookCamera] PlayerSpawn signal emitted at position: {GlobalTransform.Origin}");
+        // GD.Print($"[FreeLookCamera] PlayerSpawn signal emitted successfully.");
     }
 
     public override void _Input(InputEvent @event)

--- a/src/procgen/orchestration/behaviours/FreeLookCamera.cs
+++ b/src/procgen/orchestration/behaviours/FreeLookCamera.cs
@@ -37,6 +37,20 @@ public partial class FreeLookCamera : Camera3D
     public override void _Ready()
     {
         _checkpointPosition = GlobalTransform.Origin;
+        // Defer the PlayerSpawn signal emission to ensure all subscribers are ready
+        Callable.From(() => EmitPlayerSpawnSignal()).CallDeferred();
+
+        GD.Print($"[FreeLookCamera] Player spawned at position: {GlobalTransform.Origin}");
+    }
+
+    private void EmitPlayerSpawnSignal()
+    {
+        SignalBus.Instance.CallDeferred(
+            "emit_signal",
+            SignalBus.SignalName.PlayerSpawn,
+            GlobalTransform.Origin
+        );
+        GD.Print($"[FreeLookCamera] PlayerSpawn signal emitted at position: {GlobalTransform.Origin}");
     }
 
     public override void _Input(InputEvent @event)

--- a/src/signals/SignalBus.cs
+++ b/src/signals/SignalBus.cs
@@ -5,32 +5,35 @@ public partial class SignalBus : Node
 {
     private static SignalBus _instance;
 
-    // C# property
-    public static SignalBus Instance
-    {
-        get
-        {
-            if (_instance == null)
-            {
-                _instance = new SignalBus();
-            }
-            return _instance;
-        }
-        private set
-        {
-            _instance = value;
-        }
-    }
+    // C# property - now only has a getter. It can't create an instance.
+    public static SignalBus Instance => _instance;
 
     // GDScript accessible method
     public static SignalBus GetInstance()
     {
-        return Instance;
+        return _instance;
+    }
+
+    // Using _EnterTree is more robust for singletons as it runs before _Ready.
+    public override void _EnterTree()
+    {
+        if (_instance != null)
+        {
+            // Another instance was loaded, probably by mistake.
+            QueueFree(); 
+            return;
+        }
+        _instance = this;
     }
 
     public override void _Ready()
     {
-        _instance = this;
+        // You can keep this or remove it, as _EnterTree now handles the instance assignment.
+        // It's good practice to ensure the instance is set here as well.
+        if (_instance == null)
+        {
+            _instance = this;
+        }
     }
 
     [Signal]

--- a/src/signals/SignalBus.cs
+++ b/src/signals/SignalBus.cs
@@ -4,7 +4,7 @@ using Runevision.LayerProcGen;
 public partial class SignalBus : Node
 {
     private static SignalBus _instance;
-    
+
     // C# property
     public static SignalBus Instance
     {
@@ -21,26 +21,26 @@ public partial class SignalBus : Node
             _instance = value;
         }
     }
-    
+
     // GDScript accessible method
     public static SignalBus GetInstance()
     {
         return Instance;
     }
-    
+
     public override void _Ready()
     {
         _instance = this;
     }
-    
+
     [Signal]
     public delegate void RoadsGeneratedEventHandler(
         Vector3[] roadPositions,
-        Vector3[] roadDirections, 
+        Vector3[] roadDirections,
         int[] roadStartIndices,
         int[] roadEndIndices,
         Vector3 chunkIndex);
-    
+
     [Signal]
     public delegate void InitialRoadEndPositionsComputedEventHandler(
         Vector3[] roadStartPositions,
@@ -69,5 +69,10 @@ public partial class SignalBus : Node
         Vector3 checkpointPosition,
         Vector3 currentCameraPosition,
         float distFromCheckpoint
+    );
+
+    [Signal]
+    public delegate void PlayerSpawnEventHandler(
+        Vector3 playerPosition
     );
 }


### PR DESCRIPTION
## Description

Implement lazy evaluation for L-system village layer chunks.

Note, it would be good to have a federated way of handling this, e.g. by cascading lazy evaluation functionality.  So that I only had to lazily evaluate Play layer chunks from the GenerationSource entrypoint, and that it would be the responsibility of the Play layer to specify in its layer dependency configuration how each and every dependency should be lazily evaluated, with reasonable defaults.  And the responsibility of any of the child layers, to determine how the layer dependencies of _those_ in turn should be lazily evaluated.  etc, all the way to the leaves of the layer evaluation tree.

However this is a good starting point, I can always revisit making this logic a bit cleaner later perhaps.