### PR TITLE
Fix: Correct chunk lifecycle and data persistence logic

### DIFF
--- a/src/procgen/layers/LSystemVillageLayer.cs
+++ b/src/procgen/layers/LSystemVillageLayer.cs
@@ -126,6 +126,12 @@ public class LSystemVillageLayer : ChunkBasedDataLayer<LSystemVillageLayer, LSys
         new RoadPainterService()
     );
 
+    public LayerService GetService()
+    {
+        // GD.Print("LSystemVillageLayer.GetService called");
+        return _villageService;
+    }
+
     public Node3D layerParent;
 
 

--- a/src/procgen/layers/playLayer/VillageLayerOrchestrator.cs
+++ b/src/procgen/layers/playLayer/VillageLayerOrchestrator.cs
@@ -63,10 +63,10 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
                 var distanceToPlayer = playerXZPos.DistanceTo(chunkWorldPos);
                 bool withinRange = distanceToPlayer <= villageLoadDistance;
 
-                if (!withinRange)
-                {
-                    GD.Print($"[Initial Load] Skipping Village chunk {chunkIndex} - outside player range (distance: {distanceToPlayer:F1})");
-                }
+                // if (!withinRange)
+                // {
+                //     GD.Print($"[Initial Load] Skipping Village chunk {chunkIndex} - outside player range (distance: {distanceToPlayer:F1})");
+                // }
 
                 return withinRange;
             }
@@ -74,7 +74,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
             var initialBounds = GetBoundsAroundPosition(playerPosition, villageLoadDistance * 1.2f);
             ChunkLevelData levelData = ObjectPool<ChunkLevelData>.GlobalGet();
 
-            GD.Print($"[Initial Load] Loading Village chunks around player at {playerPosition}");
+            // GD.Print($"[Initial Load] Loading Village chunks around player at {playerPosition}");
             try
             {
                 villageLayer.EnsureLoadedInBounds(initialBounds, 0, levelData, playerPosition, ShouldCreateChunk);
@@ -106,7 +106,7 @@ namespace LayerProcGenExampleProject.ProcGen.Layers.PlayLayerComponents
             var bounds = GetBoundsAroundPosition(referencePosition, loadDistance * 1.5f);
             ChunkLevelData levelData = ObjectPool<ChunkLevelData>.GlobalGet();
 
-            GD.Print($"[Camera Movement] Updating Village chunks around camera at {referencePosition}");
+            // GD.Print($"[Camera Movement] Updating Village chunks around camera at {referencePosition}");
             try
             {
                 villageLayer.EnsureLoadedInBounds(bounds, 0, levelData, referencePosition, ShouldCreateChunk);

--- a/src/procgen/orchestration/chunks/LSystemVillageChunk.cs
+++ b/src/procgen/orchestration/chunks/LSystemVillageChunk.cs
@@ -20,12 +20,20 @@ public class LSystemVillageChunk : LayerChunk<LSystemVillageLayer, LSystemVillag
         Action done,
         LayerService service)
     {
-        var villageService = service as VillageService
-            ?? throw new InvalidCastException("Expected a VillageService");
         if (destroy)
+        {
             housePositions.Clear();
+
+            // Get the service from the layer to clear the DB records for this chunk.
+            var villageService = this.layer.GetService() as VillageService;
+            villageService?.ClearPersistedRoadChunk(this.index);
+        }
         else
+        {
+            var villageService = service as VillageService
+                ?? throw new InvalidCastException("Expected a VillageService");
             Build(ready, done, villageService);
+        }
     }
 
     public void DebugDraw() {

--- a/src/procgen/services/database/DatabaseService.cs
+++ b/src/procgen/services/database/DatabaseService.cs
@@ -91,6 +91,16 @@ namespace LayerProcGenExampleProject.Services.Database
             }
         }
 
+        public void DeleteRoadChunk(Runevision.Common.Point chunkIndex)
+        {
+            lock (_lock)
+            {
+                // Use Execute with parameters to safely delete the specific chunk's data.
+                // This targets the RoadChunkData table implicitly via its mapping.
+                _sharedConnection.Execute("DELETE FROM RoadChunkData WHERE ChunkX = ? AND ChunkY = ?", chunkIndex.x, chunkIndex.y);
+            }
+        }
+
         // Retrieves road end pairs from adjacent hamlets,
         // which were built in different LSystemVillageChunks.
         // This is useful for road generation, as it allows us to connect roads

--- a/src/procgen/services/village/VillageService.cs
+++ b/src/procgen/services/village/VillageService.cs
@@ -155,5 +155,10 @@ namespace LayerProcGenExampleProject.Services
                 RoadEndPositions = roadEndPositionsString
             });
         }
+
+        public void ClearPersistedRoadChunk(Runevision.Common.Point chunkIndex)
+        {
+            _databaseService.DeleteRoadChunk(chunkIndex);
+        }
     }
 }


### PR DESCRIPTION
This commit resolves two critical bugs related to the chunk lifecycle, preventing crashes and data corruption during procedural generation.

- Fix `InvalidCastException` in `LSystemVillageChunk.Create` The `Create` method previously attempted to cast the generic `LayerService` to a `VillageService` even when destroying a chunk (`destroy == true`). This failed because the specific service is not supplied during destruction, leading to an `InvalidCastException`. The logic has been corrected to only perform the cast when creating a chunk, while the destruction path now handles its own cleanup.
- Fix `ArgumentException` (Duplicate Key) from stale database records: When chunks were unloaded, their visual nodes were removed, but their road endpoint data was not deleted from the database. This caused a "Duplicate Key" exception when the chunk was later regenerated, as the `DatabaseService` tried to add a new record with an existing chunk coordinate key. The chunk destruction logic in `LSystemVillageChunk` has been updated to call a new method that removes the corresponding road data from the database, ensuring data consistency.