### PR TITLE
Add traffic prefab + implement RoadGraph to model road network 

### DIFF
--- a/src/procgen/models/RoadGraph.cs
+++ b/src/procgen/models/RoadGraph.cs
@@ -1,0 +1,72 @@
+using Godot;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace LayerProcGenExampleProject.Models.Graph
+{
+    public class GraphNode
+    {
+        private static int _nextId = 0;
+        public int Id { get; }
+        public Vector3 Position { get; }
+
+        public GraphNode(Vector3 position)
+        {
+            Id = System.Threading.Interlocked.Increment(ref _nextId);
+            Position = position;
+        }
+    }
+
+    public class GraphEdge
+    {
+        public GraphNode StartNode { get; }
+        public GraphNode EndNode { get; }
+        public float Length { get; }
+        public List<Vector3> Waypoints { get; } // The path the edge takes
+
+        public GraphEdge(GraphNode start, GraphNode end, List<Vector3> waypoints)
+        {
+            StartNode = start;
+            EndNode = end;
+            Waypoints = waypoints;
+            Length = CalculateLength(waypoints);
+        }
+
+        private float CalculateLength(List<Vector3> waypoints)
+        {
+            float length = 0;
+            for (int i = 0; i < waypoints.Count - 1; i++)
+            {
+                length += waypoints[i].DistanceTo(waypoints[i + 1]);
+            }
+            return length;
+        }
+    }
+
+    public class RoadGraph
+    {
+        // Thread-safe collections
+        public readonly ConcurrentDictionary<int, GraphNode> Nodes = new();
+        public readonly ConcurrentBag<GraphEdge> Edges = new();
+        private readonly ConcurrentDictionary<Vector3, GraphNode> _nodePositions = new();
+
+        public GraphNode AddNode(Vector3 position)
+        {
+            // This pattern is thread-safe with ConcurrentDictionary.
+            // It ensures that if multiple threads call this with the same position,
+            // only one will successfully create the node, and all will get it.
+            return _nodePositions.GetOrAdd(position, (pos) => {
+                var newNode = new GraphNode(pos);
+                Nodes.TryAdd(newNode.Id, newNode);
+                return newNode;
+            });
+        }
+
+        public void AddEdge(GraphNode start, GraphNode end, List<Vector3> waypoints)
+        {
+            var newEdge = new GraphEdge(start, end, waypoints);
+            // Add is thread-safe for ConcurrentBag
+            Edges.Add(newEdge);
+        }
+    }
+}

--- a/src/procgen/models/RoadGraph.cs.uid
+++ b/src/procgen/models/RoadGraph.cs.uid
@@ -1,0 +1,1 @@
+uid://b787mqkfpd4n3

--- a/src/procgen/services/road_painter/RoadPainterService.cs
+++ b/src/procgen/services/road_painter/RoadPainterService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System;
 using System.Text.Json;
 using System.Linq;
+using LayerProcGenExampleProject.Models.Graph;
 
 public class RoadPainterService
 {
@@ -108,7 +109,9 @@ public class RoadPainterService
         _needsUpdate = true;
     }
 
-    public void GenerateRoadsBetweenHamlets(List<((int, int) a, (int, int) b, string aJson, string bJson)> adjacentHamletRoadEndpoints)
+    public void GenerateRoadsBetweenHamlets(
+        List<((int, int) a, (int, int) b, string aJson, string bJson)> adjacentHamletRoadEndpoints,
+        RoadGraph roadGraph)
     {
         foreach (var (a, b, aJson, bJson) in adjacentHamletRoadEndpoints)
         {
@@ -154,7 +157,12 @@ public class RoadPainterService
 
             // GD.Print($"Generated waypoints between {a} and {b}: {waypoints.Count} waypoints.");
 
-            // Step 3. Paint the road using the waypoints.
+            // Step 3. Add the new connecting road to our graph
+            var startNode = roadGraph.AddNode(closestA);
+            var endNode = roadGraph.AddNode(closestB);
+            roadGraph.AddEdge(startNode, endNode, waypoints);
+
+            // Step 4. Paint the road using the waypoints.
             PaintRoad([.. waypoints]);
         }
     }

--- a/src/procgen/services/village/VillageService.cs
+++ b/src/procgen/services/village/VillageService.cs
@@ -6,6 +6,7 @@ using Runevision.LayerProcGen;
 using System;
 using System.Linq;
 using System.Text.Json;
+using LayerProcGenExampleProject.Models.Graph;
 
 namespace LayerProcGenExampleProject.Services
 {
@@ -14,6 +15,10 @@ namespace LayerProcGenExampleProject.Services
         private readonly DatabaseService _databaseService;
         private readonly TurtleInterpreterService _turtleInterpreterService;
         private readonly RoadPainterService _roadPainterService;
+        private readonly RoadGraph _roadGraph = new RoadGraph();
+
+        private float spacingModifier = 3.75f;
+        private float jitterRange = 150f;
 
         private bool _subscribed;
 
@@ -66,8 +71,10 @@ namespace LayerProcGenExampleProject.Services
             GD.Print($"VillageService: Retrieved adjacent hamlet endpoints: {adjacentHamletRoadEndpoints.Count} pairs.");
             // GD.Print($"VillageService: Example pair: {adjacentHamletRoadEndpoints[0].a} and {adjacentHamletRoadEndpoints[0].b}");
             // GD.Print($"VillageService: Example JSON: {adjacentHamletRoadEndpoints[0].aJson} and {adjacentHamletRoadEndpoints[0].bJson}");
+            _roadPainterService.GenerateRoadsBetweenHamlets(adjacentHamletRoadEndpoints, _roadGraph);
+
             GD.Print("VillageService: Road generation started.");
-            _roadPainterService.GenerateRoadsBetweenHamlets(adjacentHamletRoadEndpoints);
+            GD.Print($"[VillageService] Final graph contains {this._roadGraph.Nodes.Count} nodes and {this._roadGraph.Edges.Count} edges.");
         }
 
         private void OnLSystemVillageChunkReady() { }
@@ -101,6 +108,18 @@ namespace LayerProcGenExampleProject.Services
             return _databaseService.Table<RoadChunkData>().ToList();
         }
 
+        private void AddVillageToGraph(List<(Vector3, Vector3)> roadPositionDirections)
+        {
+            // Add the village chunk's roads to the road graph
+            foreach (var (startPos, endPos) in roadPositionDirections)
+            {
+                var startNode = _roadGraph.AddNode(startPos);
+                var endNode = _roadGraph.AddNode(endPos);
+                // For local roads, the waypoints are just the start and end
+                _roadGraph.AddEdge(startNode, endNode, new List<Vector3> { startPos, endPos });
+            }
+        }
+
         // ─────────────────────────────────────────────────────────────
         //  STEP 1A - house/road generation
         // ─────────────────────────────────────────────────────────────
@@ -113,8 +132,6 @@ namespace LayerProcGenExampleProject.Services
             var lSystemService = new LSystemService(seed);
             var axiom = lSystemService.SelectRandomAxiom();
 
-            float spacingModifier = 3.75f;
-            float jitterRange = 150f;
             var (jitterX, jitterZ) = lSystemService.GenerateJitter(jitterRange);
             var worldOrigin = new Vector3(
                 chunkIndex.x * layer.chunkW * spacingModifier + jitterX,
@@ -134,6 +151,10 @@ namespace LayerProcGenExampleProject.Services
             var result = new LSystemResult();
 
             _turtleInterpreterService.Interpret(sequence, state, result);
+
+            // After generating data, add the local roads to the graph
+            AddVillageToGraph(result.RoadPositionDirections);
+
             return result;
         }
 

--- a/src/scenes/l_system_prefabs/traffic.tscn
+++ b/src/scenes/l_system_prefabs/traffic.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://ypbd2rwd6kjy"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_jqevb"]
+transparency = 1
+albedo_color = Color(1, 0, 0, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_kd6a1"]
+
+[node name="Traffic" type="Node3D"]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+material_override = SubResource("StandardMaterial3D_jqevb")
+mesh = SubResource("BoxMesh_kd6a1")


### PR DESCRIPTION
## What's changing?

This change introduces a foundational data structure, `RoadGraph`, to
represent the procedurally generated road network as a graph of nodes
(intersections) and edges (road segments). This is the first step
towards enabling a dynamic traffic simulation system.

The implementation follows the strategy of building the graph in two stages:

1. **Local Graph Generation**: The `VillageService` now populates the
   `RoadGraph` with the local road network for each village as it's
   generated in `GenerateVillageData`.
2. **Global Graph Stitching**: The `RoadPainterService` then adds the
   inter-village roads to the graph when it connects adjacent hamlets,
   effectively stitching the local graphs together into a unified world
   network.

This change also addresses a critical race condition that emerged from
parallel chunk generation. The `RoadGraph` is now implemented with
thread-safe collections (`ConcurrentDictionary`, `ConcurrentBag`) to
prevent data corruption when multiple threads write to it
simultaneously.

This work enables several future enhancements for creating a dynamic
traffic system.

## What's next?

Here is a possible sequence for follow-up work, moving from foundational architecture to application logic. This order ensures each step builds on a solid prerequisite.

### Step 1: Decouple Data Generation from Rendering (Foundation)
- **What**: Modify the generation pipeline so that a larger radius of chunks around the player generate their core data (like road endpoints) and persist it to the database, without creating visual nodes (houses, roads). A smaller, inner radius handles the actual rendering.
- **Why**: This is the most critical next step. It solves the "nearest neighbor" problem in Lazy Evaluation, where if a given hamlet is not rendered, the "nearest hamlet" might not actually be the true nearest hamlet.  By querying the complete database of all known road endpoints, the `GenerateRoadsBetweenHamlets` logic will always find the true closest connection, regardless of what's currently rendered. This ensures the generated road graph is topologically correct.

### Step 2: Implement Lazy Graph Evaluation (Optimisation)
- **What**: With the full dataset available in the database, modify the `VillageService` to only hold a "live" or "active" `RoadGraph` for the chunks within the player's visual radius. As the player moves, nodes and edges would be added to or removed from this active graph.
- **Why**: This directly addresses a key feature, which is to conserve resources. Instead of holding a potentially massive graph for the entire generated world in memory, one only need process the subgraph relevant to the player's current location. This keeps memory usage low and subsequent processing (like using a CA i.e. Cellular Automata) very fast.

### Step 3: Implement Traffic Source/Sink Simulation (Application)
- **What**: Create a new service that, on a timer (e.g., every 5 seconds), runs some cellular automata logic. This service would iterate over the nodes in the active `RoadGraph` from Step 2. For each node, it would apply probabilistic rules to determine if it should become a traffic source or sink.
- **Why**: This is the fun part where the world comes alive. Because it runs on the lazily-evaluated subgraph, it remains computationally cheap and scalable, no matter how large the world becomes. The results of this simulation would then be used by a future traffic/vehicle agent system.

This sequence provides a robust path forward, ensuring that the data is correct before one optimises it, and that it's optimised before one builds complex application logic on top of it.