### PR TITLE
fix(ProcGen): Ensure all scene and rendering operations are on the main thread

### DIFF
--- a/src/procgen/orchestration/chunks/LSystemVillageChunk.cs
+++ b/src/procgen/orchestration/chunks/LSystemVillageChunk.cs
@@ -11,7 +11,7 @@ public class LSystemVillageChunk : LayerChunk<LSystemVillageLayer, LSystemVillag
 {
     List<Vector3> housePositions = new();
     private Node3D? _chunkParent; 
-    private readonly List<Node3D> _pendingHouses = new();
+    private readonly List<Vector3> _pendingHousePositions = new();
 
     public override void Create(
         int level,
@@ -111,39 +111,39 @@ public class LSystemVillageChunk : LayerChunk<LSystemVillageLayer, LSystemVillag
 
     void QueueHouseInstance(Vector3 position)
     {
+        // This runs on a background thread.
+        // Only perform thread-safe calculations here.
         position.Y = GetHeightAt(position);
-
-        var houseScene = GD.Load<PackedScene>(
-            "res://src/scenes/l_system_prefabs/house.tscn");
-        var inst = houseScene.Instantiate<Node3D>();
-        inst.Position = position;
-
-        _pendingHouses.Add(inst); 
+        // Do not call GD.Load or Instantiate(). Just store the data.
+        _pendingHousePositions.Add(position);
     }
 
     void FlushHousesToScene()
     {
-        // GD.Print("LSystemVillageChunk FlushHousesToScene");
-        if (_pendingHouses.Count == 0) return;
+        if (_pendingHousePositions.Count == 0) return;
 
-        // Copy to Godot Array so it survives the lambda capture
-        var batch = new Godot.Collections.Array<Node3D>(_pendingHouses.Cast<Node3D>());
+        // Copy the positions to a Godot Array so it survives the lambda capture.
+        var batch = new Godot.Collections.Array<Vector3>(_pendingHousePositions);
+        // Clear the list for the next build cycle.
+        _pendingHousePositions.Clear();
 
-        // Clear the list for the next build cycle
-        _pendingHouses.Clear();
-
-        // Schedule the whole batch to be added next frame
+        // Schedule the Godot-related work to run on the main thread.
         SceneTree tree = (SceneTree)Engine.GetMainLoop();
         tree.CreateTimer(0)                           // 0-sec One-Shot Timer
             .Connect("timeout",
                 Callable.From(() =>
                 {
-                    var parent = GetChunkParent();    // now definitely in tree
-                    // GD.Print("Adding " + batch.Count + " houses to scene for parent " + parent.Name);
-                    foreach (Node3D houseNode in batch)
+                    // This code now runs safely on the main thread.
+                    var parent = GetChunkParent();
+                    // Load the scene once, outside the loop.
+                    var houseScene = GD.Load<PackedScene>("res://src/scenes/l_system_prefabs/house.tscn");
+
+                    foreach (Vector3 position in batch)
                     {
-                        houseNode.Name = "House_" + houseNode.Position.ToString();
-                        parent.AddChild(houseNode);
+                        var inst = houseScene.Instantiate<Node3D>();
+                        inst.Position = position;
+                        inst.Name = "House_" + inst.Position.ToString();
+                        parent.AddChild(inst);
                     }
                 }));
     }

--- a/src/procgen/services/road_painter/RoadPainterService.cs
+++ b/src/procgen/services/road_painter/RoadPainterService.cs
@@ -113,6 +113,11 @@ public class RoadPainterService
         List<((int, int) a, (int, int) b, string aJson, string bJson)> adjacentHamletRoadEndpoints,
         RoadGraph roadGraph)
     {
+        // This method is called from a background thread.
+        // We can do all the data processing and graph updates here,
+        // but the actual painting must be deferred to the main thread.
+        var allWaypointsToPaint = new List<Vector3[]>();
+
         foreach (var (a, b, aJson, bJson) in adjacentHamletRoadEndpoints)
         {
             // Use the endpoints (a, b) to generate roads between the hamlets.
@@ -162,8 +167,19 @@ public class RoadPainterService
             var endNode = roadGraph.AddNode(closestB);
             roadGraph.AddEdge(startNode, endNode, waypoints);
 
-            // Step 4. Paint the road using the waypoints.
-            PaintRoad([.. waypoints]);
+            // Step 4. Collect the waypoints to be painted later.
+            allWaypointsToPaint.Add(waypoints.ToArray());
+        }
+
+        // If there's anything to paint, schedule it on the main thread.
+        if (allWaypointsToPaint.Any())
+        {
+            Callable.From(() => {
+                foreach(var waypoints in allWaypointsToPaint)
+                {
+                    PaintRoad(waypoints);
+                }
+            }).CallDeferred();
         }
     }
 

--- a/src/procgen/services/village/VillageService.cs
+++ b/src/procgen/services/village/VillageService.cs
@@ -86,9 +86,12 @@ namespace LayerProcGenExampleProject.Services
             int[] roadEndIndices,
             Vector3 chunkIndex)
         {
-            // Handle the event when roads are generated.
-            // GD.Print("Received RoadsGenerated signal with chunk index: ", chunkIndex);
-            _roadPainterService.PaintRoad(roadPositions, roadStartIndices, roadEndIndices);
+            // This handler is executed on a background thread.
+            // We must defer the actual painting (which interacts with the scene tree)
+            // to the main thread to prevent race conditions.
+            Callable.From(() =>
+                _roadPainterService.PaintRoad(roadPositions, roadStartIndices, roadEndIndices)
+            ).CallDeferred();
         }
 
         private void OnRoadPainterServiceTimerTimeout()


### PR DESCRIPTION
This commit resolves critical race conditions that caused intermittent crashes and visual artifacts during procedural generation. The underlying issue was that the parallelised chunk generation was calling Godot APIs that are not thread-safe from background threads.

Two specific problems have been fixed:

1. **Corrupted House Meshes**: `PackedScene.Instantiate()` was being called from multiple background threads, leading to corrupted mesh data and a low-level rendering crash (`mesh->surface_count = 0`). The logic has been refactored to only calculate house positions on the background threads, while the actual `GD.Load` and `Instantiate` operations are now correctly deferred to the main thread.
2. **Intermittent Road Painting**: The `RoadPainterService` was being invoked from background threads via signal handlers, causing its calls to the terrain system (`Storage.SetControl`) to fail silently. This resulted in roads being randomly missed. All road painting calls are now also deferred to the main thread, ensuring they execute safely.

By enforcing the rule that all interactions with the scene tree and rendering server must happen on the main thread, the procedural generation pipeline is now significantly more stable and reliable.